### PR TITLE
Named lookup

### DIFF
--- a/src/Commands/HandlersList.php
+++ b/src/Commands/HandlersList.php
@@ -6,7 +6,7 @@ use Tatter\Handlers\Handlers;
 
 class HandlersList extends BaseCommand
 {
-    protected $group       = 'Handlers';
+    protected $group       = 'Housekeeping';
     protected $name        = 'handlers:list';
     protected $description = 'List all discovered handlers';
 	protected $usage       = 'handlers:list';

--- a/src/Commands/HandlersRegister.php
+++ b/src/Commands/HandlersRegister.php
@@ -6,7 +6,7 @@ use Tatter\Handlers\Handlers;
 
 class HandlersRegister extends BaseCommand
 {
-    protected $group       = 'Handlers';
+    protected $group       = 'Housekeeping';
     protected $name        = 'handlers:register';
     protected $description = 'Regsiter all discovered handlers';
 	protected $usage       = 'handlers:register';

--- a/src/Commands/HandlersReset.php
+++ b/src/Commands/HandlersReset.php
@@ -6,7 +6,7 @@ use Tatter\Handlers\Handlers;
 
 class HandlersReset extends BaseCommand
 {
-    protected $group       = 'Handlers';
+    protected $group       = 'Housekeeping';
     protected $name        = 'handlers:reset';
     protected $description = 'Clear cached versions of discovered handlers';
 	protected $usage       = 'handlers:reset';

--- a/src/Handlers.php
+++ b/src/Handlers.php
@@ -94,6 +94,8 @@ class Handlers
 		return $this;
 	}
 
+	//--------------------------------------------------------------------
+
 	/**
 	 * Adds attribute criteria.
 	 *
@@ -146,6 +148,53 @@ class Handlers
 		$this->reset();
 		return $classes;
 	}
+
+	/**
+	 * Returns a handler with a given name. Ignores filters.
+	 * Searches: attribute "name" or "uid", namespaced class, and short class name.
+	 *
+	 * @param string $name  The name of the handler
+	 *
+	 * @return string|null  The full class name, or null if none found
+	 */
+	public function named(string $name): ?string
+	{
+		$this->discoverHandlers();
+
+		$name = trim($name, '\\ ');
+
+		foreach ($this->discovered as $class => $attributes)
+		{
+			// Check the namespaced class
+			if ($class === $name)
+			{
+				return $class;
+			}
+
+			// Check the attributes
+			if (isset($attributes['name']) && $attributes['name'] === $name)
+			{
+				return $class;
+			}
+			if (isset($attributes['uid']) && $attributes['uid'] === $name)
+			{
+				return $class;
+			}
+
+			// Check the class shortname
+			if ($pos = strrpos($class, '\\'))
+			{
+				if (substr($class, $pos + 1) === $name)
+				{
+					return $class;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	//--------------------------------------------------------------------
 
 	/**
 	 * Iterates through discovered handlers and attempts to register them.

--- a/tests/unit/LibraryTest.php
+++ b/tests/unit/LibraryTest.php
@@ -79,67 +79,6 @@ class LibraryTest extends HandlerTestCase
 		$this->assertCount($limit, $result);
 	}
 
-	public function testAllDiscoversAll()
-	{
-		$expected = [
-			'Tests\Support\Factories\PopFactory',
-			'Tests\Support\Factories\WidgetFactory',
-		];
-
-		$result = $this->handlers->all();
-
-		$this->assertEquals($expected, $result);
-	}
-
-	public function testAllRespectsCriteria()
-	{
-		$expected = [
-			'Tests\Support\Factories\WidgetFactory',
-		];
-
-		$result = $this->handlers->where(['uid' => 'widget'])->all();
-
-		$this->assertEquals($expected, $result);
-	}
-
-	public function testAllResetsCriteria()
-	{
-		$this->handlers->where(['uid' => 'widget'])->all();
-
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
-
-		$this->assertEquals([], $result);
-	}
-
-	public function testFirstReturnsSingleton()
-	{
-		$expected = 'Tests\Support\Factories\PopFactory';
-
-		$result = $this->handlers->first();
-
-		$this->assertEquals($expected, $result);
-	}
-
-	public function testFirstRespectsCriteria()
-	{
-		$expected = [
-			'Tests\Support\Factories\WidgetFactory',
-		];
-
-		$result = $this->handlers->where(['uid' => 'widget'])->all();
-
-		$this->assertEquals($expected, $result);
-	}
-
-	public function testFirstResetsCriteria()
-	{
-		$this->handlers->where(['uid' => 'widget'])->first();
-
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
-
-		$this->assertEquals([], $result);
-	}
-
 	public function testRegisterCallsHandlerRegister()
 	{
 		$this->handlers->register();

--- a/tests/unit/SearchTest.php
+++ b/tests/unit/SearchTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Tatter\Handlers\BaseHandler;
+use Tatter\Handlers\Handlers;
+use Tatter\Handlers\Config\Handlers as HandlersConfig;
+use Tests\Support\HandlerTestCase;
+
+class SearchTest extends HandlerTestCase
+{
+	public function testAllDiscoversAll()
+	{
+		$expected = [
+			'Tests\Support\Factories\PopFactory',
+			'Tests\Support\Factories\WidgetFactory',
+		];
+
+		$result = $this->handlers->all();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testAllRespectsCriteria()
+	{
+		$expected = [
+			'Tests\Support\Factories\WidgetFactory',
+		];
+
+		$result = $this->handlers->where(['uid' => 'widget'])->all();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testAllResetsCriteria()
+	{
+		$this->handlers->where(['uid' => 'widget'])->all();
+
+		$result = $this->getPrivateProperty($this->handlers, 'criteria');
+
+		$this->assertEquals([], $result);
+	}
+
+	public function testFirstReturnsSingleton()
+	{
+		$expected = 'Tests\Support\Factories\PopFactory';
+
+		$result = $this->handlers->first();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testFirstRespectsCriteria()
+	{
+		$expected = [
+			'Tests\Support\Factories\WidgetFactory',
+		];
+
+		$result = $this->handlers->where(['uid' => 'widget'])->all();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testFirstResetsCriteria()
+	{
+		$this->handlers->where(['uid' => 'widget'])->first();
+
+		$result = $this->getPrivateProperty($this->handlers, 'criteria');
+
+		$this->assertEquals([], $result);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @dataProvider provideNames
+	 */
+	public function testNamedFindsMatch($name, $success)
+	{
+		$result = $this->handlers->named($name);
+
+		$this->assertEquals($success, (bool) $result);
+	}
+
+	public function provideNames()
+	{
+		return [
+			['',                                        false],
+			[' ',                                       false],
+			['pop',                                     true],
+			['PopFactory',                              true],
+			['Pop Factory',                             true],
+			['Bad Factory',                             false],
+			['Not A Factory',                           false],
+			['Tests\\Support\\Factories',               false],
+			['Tests\\Support\Factories\\PopFactory',    true],
+			['\\Tests\\Support\\Factories\\PopFactory', true],
+		];
+	}
+}


### PR DESCRIPTION
Adds `named()` method for locating a specific handler by its attributes (name, uid) or class (namespaces, short).