### PR TITLE
Implement Model-like methods

### DIFF
--- a/src/Handlers.php
+++ b/src/Handlers.php
@@ -344,8 +344,16 @@ class Handlers
 						$test = $attributes[$key] === $value;
 					break;
 
+					case '>':
+						$test = $attributes[$key] > $value;						
+					break;
+
 					case '>=':
 						$test = $attributes[$key] >= $value;						
+					break;
+
+					case '<':
+						$test = $attributes[$key] < $value;
 					break;
 
 					case '<=':

--- a/tests/_support/Factories/PopFactory.php
+++ b/tests/_support/Factories/PopFactory.php
@@ -12,6 +12,8 @@ class PopFactory implements HandlerInterface
 		'name'    => 'Pop Factory',
 		'uid'     => 'pop',
 		'summary' => 'Makes pop',
+		'cost'    => 1,
+		'list'    => 'five,six',
 	];
 
 	public function process()

--- a/tests/_support/Factories/WidgetFactory.php
+++ b/tests/_support/Factories/WidgetFactory.php
@@ -10,6 +10,8 @@ class WidgetFactory extends BaseHandler
 		'name'    => 'Widget Plant',
 		'uid'     => 'widget',
 		'summary' => "The world's largest supplier of widgets!",
+		'cost'    => 10,
+		'list'    => 'one,two,three,four',
 	];
 
 	public function process()

--- a/tests/unit/LibraryTest.php
+++ b/tests/unit/LibraryTest.php
@@ -29,25 +29,30 @@ class LibraryTest extends HandlerTestCase
 		$this->assertEquals($path, $result);
 	}
 
-	public function testWhereMergesCriteria()
+	public function testWhereCombinesFilters()
 	{
 		$this->handlers->where(['group' => 'East']);
 
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
-		$this->assertEquals($result, ['group' => 'East']);
+		$result = $this->getPrivateProperty($this->handlers, 'filters');
+		$this->assertEquals($result, [
+			['group', '==', 'East', true],
+		]);
 
 		$this->handlers->where(['uid' => 'pop']);
 
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
-		$this->assertEquals($result, ['group' => 'East', 'uid' => 'pop']);
+		$result = $this->getPrivateProperty($this->handlers, 'filters');
+		$this->assertEquals($result, [
+			['group', '==', 'East', true],
+			['uid', '==', 'pop', true],
+		]);
 	}
 
-	public function testResetClearsCriteria()
+	public function testResetClearsFilters()
 	{
 		$this->handlers->where(['group' => 'East']);
 		$this->handlers->reset();
 
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
+		$result = $this->getPrivateProperty($this->handlers, 'filters');
 		$this->assertEquals($result, []);
 	}
 

--- a/tests/unit/SearchTest.php
+++ b/tests/unit/SearchTest.php
@@ -18,6 +18,28 @@ class SearchTest extends HandlerTestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testWhereUsesOperators()
+	{
+		$expected = ['Tests\Support\Factories\WidgetFactory'];
+
+		$result = $this->handlers
+			->where(['cost >' => 5])
+			->findAll();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testWhereSupportsCsv()
+	{
+		$expected = ['Tests\Support\Factories\WidgetFactory'];
+
+		$result = $this->handlers
+			->where(['list has' => 'three'])
+			->findAll();
+
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testWhereMissingAttribute()
 	{
 		$result = $this->handlers

--- a/tests/unit/SearchTest.php
+++ b/tests/unit/SearchTest.php
@@ -7,34 +7,68 @@ use Tests\Support\HandlerTestCase;
 
 class SearchTest extends HandlerTestCase
 {
-	public function testAllDiscoversAll()
+	public function testWhereFilters()
+	{
+		$expected = ['Tests\Support\Factories\WidgetFactory'];
+
+		$result = $this->handlers
+			->where(['uid' => 'widget'])
+			->findAll();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testWhereMissingAttribute()
+	{
+		$result = $this->handlers
+			->where(['foo' => 'bar'])
+			->findAll();
+
+		$this->assertEquals([], $result);
+	}
+
+	public function testOrWhereIgnoresOtherFilters()
+	{
+		$expected = ['Tests\Support\Factories\WidgetFactory'];
+
+		$result = $this->handlers
+			->where(['foo' => 'bar'])
+			->orWhere(['uid' => 'widget'])
+			->findAll();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testFindAllDiscoversAll()
 	{
 		$expected = [
 			'Tests\Support\Factories\PopFactory',
 			'Tests\Support\Factories\WidgetFactory',
 		];
 
-		$result = $this->handlers->all();
+		$result = $this->handlers->findAll();
 
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testAllRespectsCriteria()
+	public function testFindAllRespectsFilters()
 	{
 		$expected = [
 			'Tests\Support\Factories\WidgetFactory',
 		];
 
-		$result = $this->handlers->where(['uid' => 'widget'])->all();
+		$result = $this->handlers->where(['uid' => 'widget'])->findAll();
 
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testAllResetsCriteria()
+	public function testFindAllResetsFilters()
 	{
-		$this->handlers->where(['uid' => 'widget'])->all();
+		$this->handlers->where(['uid' => 'widget'])->findAll();
 
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
+		$result = $this->getPrivateProperty($this->handlers, 'filters');
 
 		$this->assertEquals([], $result);
 	}
@@ -48,22 +82,20 @@ class SearchTest extends HandlerTestCase
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testFirstRespectsCriteria()
+	public function testFirstRespectsFilters()
 	{
-		$expected = [
-			'Tests\Support\Factories\WidgetFactory',
-		];
+		$expected = 'Tests\Support\Factories\WidgetFactory';
 
-		$result = $this->handlers->where(['uid' => 'widget'])->all();
+		$result = $this->handlers->where(['uid' => 'widget'])->first();
 
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testFirstResetsCriteria()
+	public function testFirstResetsFilters()
 	{
 		$this->handlers->where(['uid' => 'widget'])->first();
 
-		$result = $this->getPrivateProperty($this->handlers, 'criteria');
+		$result = $this->getPrivateProperty($this->handlers, 'filters');
 
 		$this->assertEquals([], $result);
 	}
@@ -73,9 +105,9 @@ class SearchTest extends HandlerTestCase
 	/**
 	 * @dataProvider provideNames
 	 */
-	public function testNamedFindsMatch($name, $success)
+	public function testFindFindsMatch($name, $success)
 	{
-		$result = $this->handlers->named($name);
+		$result = $this->handlers->find($name);
 
 		$this->assertEquals($success, (bool) $result);
 	}


### PR DESCRIPTION
In an effort to make searching easier and more intuitive, this PR adjusts **Handlers** to use methods similar to `CodeIgniter\Model`.

* Methods `all()` and `named($name)` are now deprecated in favor or `findAll()` and `find($name)` respectively.
* Search criteria has been revamped to accept operators, e.g.: `$handlers->where(['cost >' => 5])->first()`
* Searching now has a "short circuit" option for matching one criterium: `$handlers->orWhere(['extension' => '*'])->findAll()`
