### PR TITLE
Add service and helper

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,13 +4,12 @@ parameters:
 	paths:
 		- src
 		- tests
-	ignoreErrors:
-		- '#Constant SUPPORTPATH not found#'
 	bootstrapFiles:
-		- phpstan-bootstrap.php
+		- vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php
 	scanDirectories:
 		- vendor/codeigniter4/codeigniter4/system/Helpers
 	dynamicConstantNames:
 		- ENVIRONMENT
 		- CI_DEBUG
-	treatPhpDocTypesAsCertain: false
+	ignoreErrors:
+		- '#Call to an undefined static method Config\\Services::handlers\(\)#'

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -1,0 +1,25 @@
+<?php namespace Tatter\Handlers\Config;
+
+use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Config\BaseService;
+use Tatter\Handlers\Handlers;
+use Tatter\Handlers\Config\Handlers as HandlersConfig;
+
+class Services extends BaseService
+{
+	/**
+	 * @param string $path
+	 * @param HandlersConfig|null $config
+	 * @param CacheInterface|null $cache
+	 * @param boolean $getShared
+	 */
+    public static function handlers(string $path = '', HandlersConfig $config = null, CacheInterface $cache = null, bool $getShared = true)
+    {
+		if ($getShared)
+		{
+			return static::getSharedInstance('handlers', $path, $config, $cache);
+		}
+
+		return new Handlers($path, $config, $cache);
+	}
+}

--- a/src/Helpers/handlers_helper.php
+++ b/src/Helpers/handlers_helper.php
@@ -1,0 +1,19 @@
+<?php
+
+use Config\Services;
+use Tatter\Handlers\Handlers;
+
+if (! function_exists('handlers'))
+{
+	/**
+	 * Returns the Handlers service set to the specified path.
+	 *
+	 * @param string $path
+	 *
+	 * @return Handlers
+	 */
+	function handlers(string $path = ''): Handlers
+	{
+		return $path ? Services::handlers()->setPath($path) : Services::handlers();
+	}
+}

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Tatter\Handlers\Handlers;
+use Tests\Support\HandlerTestCase;
+
+class HelperTest extends HandlerTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		helper('handlers');
+	}
+
+	public function testHelperReturnsLibrary()
+	{
+		$result = handlers();
+
+		$this->assertInstanceOf(Handlers::class, $result);
+	}
+
+	public function testHelperRetainsPath()
+	{
+		$path   = 'Marmalade';
+		handlers($path);
+		
+		$result = handlers()->getPath();
+
+		$this->assertEquals($path, $result);
+	}
+}


### PR DESCRIPTION
Adds a simple Handlers Service to allow access to the shared instance, and a new helper function to make trivial calls simpler:
```
$class   = handlers('Widgets')->first();
$another = handlers()->where(['files has' => 'example.pdf'])->first();
```
