### PR TITLE
Additional Interfaces

### DIFF
--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -71,6 +71,16 @@ abstract class BaseFactory
     }
 
     /**
+     * Returns the interface required for handlers to match.
+     *
+     * @return class-string<HandlerInterface>
+     */
+    public function getInterface(): string
+    {
+        return HandlerInterface::class;
+    }
+
+    /**
      * Returns the current configuration.
      */
     final public function getConfig(): HandlersConfig
@@ -343,8 +353,8 @@ abstract class BaseFactory
     }
 
     /**
-     * Validates that a file path contains a HandlerInterface and
-     * returns its full class name.
+     * Validates that a file path contains a HandlerInterface
+     * (or $this->getInterface()) and returns its full class name.
      *
      * @param string $file      Full path to the file in question
      * @param string $namespace The file's namespace
@@ -380,8 +390,10 @@ abstract class BaseFactory
         if (! $interfaces = class_implements($class)) {
             return null;
         }
-
         if (! in_array(HandlerInterface::class, $interfaces, true)) {
+            return null;
+        }
+        if (! in_array($this->getInterface(), $interfaces, true)) {
             return null;
         }
 

--- a/tests/BaseFactoryTest.php
+++ b/tests/BaseFactoryTest.php
@@ -3,6 +3,7 @@
 use Tatter\Handlers\BaseFactory;
 use Tatter\Handlers\Config\Handlers as HandlersConfig;
 use Tests\Support\Factories\CarFactory;
+use Tests\Support\Factories\ExtendedFactory;
 use Tests\Support\TestCase;
 
 /**
@@ -85,6 +86,17 @@ final class BaseFactoryTest extends TestCase
         $result = $this->factory->getHandlerClass($file, 'Tests\Support');
 
         $this->assertSame($expected, $result);
+    }
+
+    public function testGetHandlerClassUsesExtendedInterface()
+    {
+        $factory = new ExtendedFactory();
+
+        $result = $factory->getHandlerClass(SUPPORTPATH . 'Cars/WidgetCar.php', 'Tests\Support');
+        $this->assertSame('Tests\Support\Cars\WidgetCar', $result);
+
+        $result = $factory->getHandlerClass(SUPPORTPATH . 'Cars/PopCar.php', 'Tests\Support');
+        $this->assertNull($result);
     }
 
     public function testGetHandlerClassRequiresPhpExtension()

--- a/tests/FactoryFactoryTest.php
+++ b/tests/FactoryFactoryTest.php
@@ -2,6 +2,7 @@
 
 use Tatter\Handlers\Factories\FactoryFactory;
 use Tests\Support\Factories\CarFactory;
+use Tests\Support\Factories\ExtendedFactory;
 use Tests\Support\TestCase;
 
 /**
@@ -14,6 +15,7 @@ final class FactoryFactoryTest extends TestCase
         // Discovery is alphabetical by handlerId
         $expected = [
             CarFactory::class,
+            ExtendedFactory::class,
             FactoryFactory::class,
         ];
 

--- a/tests/_support/Cars/WidgetCar.php
+++ b/tests/_support/Cars/WidgetCar.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Support\Cars;
 
-use Tatter\Handlers\Interfaces\HandlerInterface;
+use Tests\Support\Interfaces\ExtendedInterface;
 
-class WidgetCar implements HandlerInterface
+class WidgetCar implements ExtendedInterface
 {
     /**
      * Returns this handler's identifier,

--- a/tests/_support/Factories/ExtendedFactory.php
+++ b/tests/_support/Factories/ExtendedFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Support\Factories;
+
+use Tests\Support\Interfaces\ExtendedInterface;
+
+class ExtendedFactory extends CarFactory
+{
+    public static function handlerId(): string
+    {
+        return 'extended';
+    }
+
+    public function getInterface(): string
+    {
+        return ExtendedInterface::class;
+    }
+}

--- a/tests/_support/Interfaces/ExtendedInterface.php
+++ b/tests/_support/Interfaces/ExtendedInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support\Interfaces;
+
+use Tatter\Handlers\Interfaces\HandlerInterface;
+
+/**
+ * An empty interface, to verify that handler classes
+ * can use an their own interface extension.
+ */
+interface ExtendedInterface extends HandlerInterface
+{
+}


### PR DESCRIPTION
Adds the `getInterface()` method to allow Factories to specify an extended `HandlerInterface` to filter by instead.