### PR TITLE
Factory Usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Supply the following static methods then implement `Tatter\Handlers\Interfaces\H
 * `public static handlerId(): string`: Returns a unique slug identifier for this class
 * `public static attributes(): array`: Returns an array of attributes about this handler
 
-If you would like to filter by a more specific version you may supply an extended version
-of `HandlerInterface` via the method `BaseFactory::getInterface(): string`.
+If you would like to filter by a more specific version you may supply an additional class
+or interface name as the Factory class constant `RETURN_TYPE`.
 
 > Note: See **src/Interfaces/HandlerInterface.php** for more details.
 
@@ -97,19 +97,11 @@ $class = $widgets->find('FancyHandler');
 ```
 
 If you want your Factory to search for a more specific interface then add the class string
-as a return from your Factory's `getInterface()` method:
+to the class constant `RETURN_TYPE`:
 ```php
 class WidgetFactory extends BaseFactory
 {
-    /**
-     * Returns the interface required for handlers to match.
-     *
-     * @return class-string<HandlerInterface>
-     */
-    public function getInterface(): string
-    {
-        return 'App\Interfaces\WidgetInterface';
-    }
+    public const RETURN_TYPE = 'App\Interfaces\WidgetInterface';
 ...
 ```
 
@@ -122,10 +114,10 @@ using the config file by setting `$cacheDuration` to `null`.
 
 Often it is a good idea to pre-cache handlers so the filesystem search does not happen on
 an actual page load. This library includes `FactoryFactory`, a "Factory to discover other
-Factories". if you would like your Factories to be discoverable by `FactoryFactory` and
+Factories". If you would like your Factories to be discoverable by `FactoryFactory` and
 thus their handlers enabled for auto-caching then place your Factory classes in the
-**Factories** subfolder and have them fulfill the `HandlerInterface` methods just like any
-other handlers.
+**Factories** subfolder. Factories autodetect their attributes for `HandlerInterface` but
+you may supply the overriding methods just like any other handlers.
 
 ### Commands
 

--- a/src/Factories/FactoryFactory.php
+++ b/src/Factories/FactoryFactory.php
@@ -13,16 +13,13 @@ use Tatter\Handlers\Interfaces\HandlerInterface;
  */
 class FactoryFactory extends BaseFactory implements HandlerInterface
 {
+    /**
+     * Use Factories-style class basenames to
+     * guesstimate a good handlerId.
+     */
     public static function handlerId(): string
     {
-        return 'factories';
-    }
-
-    public static function attributes(): array
-    {
-        return [
-            'name' => 'Factory of Factories',
-        ];
+        return 'factory';
     }
 
     /**

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -55,7 +55,7 @@ final class CommandsTest extends TestCase
 
         $result = cache()->get('handlers-factories');
         $this->assertCount(3, $result);
-        $this->assertSame(['cars', 'extended', 'factories'], array_keys($result));
+        $this->assertSame(['car', 'extended', 'factory'], array_keys($result));
 
         $result = cache()->get('handlers-cars');
         $this->assertCount(2, $result);

--- a/tests/_support/Factories/CarFactory.php
+++ b/tests/_support/Factories/CarFactory.php
@@ -7,18 +7,6 @@ use Tatter\Handlers\Interfaces\HandlerInterface;
 
 class CarFactory extends BaseFactory implements HandlerInterface
 {
-    public static function handlerId(): string
-    {
-        return 'cars';
-    }
-
-    public static function attributes(): array
-    {
-        return [
-            'name' => 'Factory of Cars',
-        ];
-    }
-
     /**
      * Returns the search path.
      */

--- a/tests/_support/Factories/ExtendedFactory.php
+++ b/tests/_support/Factories/ExtendedFactory.php
@@ -6,13 +6,17 @@ use Tests\Support\Interfaces\ExtendedInterface;
 
 class ExtendedFactory extends CarFactory
 {
+    public const RETURN_TYPE = ExtendedInterface::class;
+
     public static function handlerId(): string
     {
         return 'extended';
     }
 
-    public function getInterface(): string
+    public static function attributes(): array
     {
-        return ExtendedInterface::class;
+        return [
+            'name' => 'Factory of Extended Cars',
+        ];
     }
 }


### PR DESCRIPTION
* Moves interface filters to a public constant and expands it to any class.
* Supplies auto-detecting `HandlerInterface` methods to `BaseFactory` to make detection easier.